### PR TITLE
fix bug in MedusaClient when initialized without headers

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -147,8 +147,10 @@ export class MedusaClient {
    async query(options: QueryOptions): Promise<Response|null> {
       const { locals, path, method = 'GET', body = {} } = options
       let headers: any = {}
-      for (const [key, value] of Object.entries(this.headers)) {
-         headers[key] = value
+      if (this.headers) {
+        for (const [key, value] of Object.entries(this.headers)) {
+           headers[key] = value
+        }
       }
       if (locals && locals.sid) {
          headers['Cookie'] = `connect.sid=${locals.sid}`


### PR DESCRIPTION
This pull request fixes the "TypeError: Cannot convert undefined or null to object" bug that occurs when MedusaClient is initialized without any header options.

Link to issue: [https://github.com/pevey/sveltekit-medusa-client/issues/1](url)